### PR TITLE
Allow diskpart.ps1 to work under R4.0 // Ensure target volume is approximately empty before overwriting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Here is short how-to instructions to build using disposable VM in Qubes R4.1 pre
 
 1. Setup build environment
 ```
-sudo dnf install git make mock
+cd ~
+sudo dnf -y install git make mock
 git clone https://github.com/QubesOS/qubes-builder
 cd qubes-builder
 make install-deps
@@ -19,7 +20,7 @@ make BUILDERCONF=example-configs/qubes-os-r4.1.conf BASEURL=https://github.com G
 ```
 make BUILDERCONF=example-configs/qubes-os-r4.1.conf COMPONENTS=windows-tools-cross windows-tools-cross-dom0
 ```
-4. Extract result package in disposable VM to get temporary CDROM device available
+4. Extract result package in disposable VM to get temporary CDROM device available [Note: you may need to add --nosignature to the rpm invocation to extract the ISO.]
 ```
 sudo rpm -Uhv qubes-packages-mirror-repo/dom0-fc32/rpm/qubes-windows-tools*.noarch.rpm
 sudo losetup -f /usr/lib/qubes/qubes-windows-tools.iso

--- a/diskpart.ps1
+++ b/diskpart.ps1
@@ -1,4 +1,71 @@
-if (-not (Get-PSDrive Q) -and (Get-WmiObject Win32_physicalMedia |where {$_.serialnumber -match "QM00002"}))
+# This routine:
+#   Gets the Qubes private volume
+#   Verifies that disk header is nearly all zeros (e.g. never initialized or re-cleared via diskpart's clean command)
+#   Verifies that Q drive does not yet exist
+#   Formats as "Qubes Private Image" 
+#   Assigns letter Q:
+#
+# Note: Private should always be found on PHYSICALDRIVE1 (in Windows under Qubes, that's: 0=BOOT/1=PRIVATE/2=VOLATILE).
+# Note: \\.\PHYSICALDRIVE1 and diskpart's "select disk 1" are assumed to be equivalent.
+# Note: This removes the QM00002 serial number check (which fails in Qubes R4.0).
+
+# We can utilize PInvoke to call win32 API to get raw disk handle
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class PInvoke {
+    [DllImport("kernel32.dll")] public static extern IntPtr CreateFile(string lpFileName, int dwDesiredAccess, int dwShareMode, IntPtr lpSecurityAttributes, int dwCreationDisposition, int dwFlagsAndAttributes, IntPtr hTemplateFile);
+}
+"@
+
+# Set $bytecount to disk header size
+$blocksize=512
+$blockcount=64
+$bytecount=$blocksize*$blockcount # number of bytes to check at start of disk to "prove" disk is empty.
+
+# Threshold of unexpected bytes
+$maxunexpected=5
+
+# Get raw device with appropriate flags
+$handle = [PInvoke]::CreateFile('\\.\PhysicalDrive1', 0x80000000, 6, 0, 3, 0, 0)
+
+# Convert handle to Powershell object
+$fs = New-Object System.IO.FileStream ($handle, 'Read', $true)
+
+# Set up array to hold disk header data
+$b = [array]::CreateInstance([byte], $bytecount)
+
+# Instead of real error handling around the Read below we'll...
+# ...pre-populate with data that should fail the empty if not overwritten by a good read
+$b[0] = 255 
+
+# Read raw volume data into array and clean up object
+$fs.Read($b, 0, $bytecount) | Out-Null
+$fs.Dispose()
+
+# Create flag for whether device is empty
+$headerempty = 1
+
+# Create counter for stray non-zero bytes
+$nonzerocounter = 0
+
+# Check buffer to ensure for all bytes are zeros
+# For some reason, on a new Qubes install, I found two 0x4B aka 75 bytes in the upper half of the first 512-byte block
+foreach($byte in $b)
+{
+	if (($byte -ne 0) -and ($byte -ne 75))
+	{
+		$nonzerocounter++
+	}
+}
+
+if ($nonzerocounter -gt $maxunexpected)
+{
+	$headerempty = 0
+}
+
+# Only invoke diskpart if the header is empty and the Q drive is missing.
+if (($headerempty -ne 0) -and (-not (Get-PSDrive Q)))
 {
 @"
   select disk 1
@@ -9,3 +76,7 @@ if (-not (Get-PSDrive Q) -and (Get-WmiObject Win32_physicalMedia |where {$_.seri
   assign letter="Q"
 "@|diskpart
 }
+
+# Write data to file for debugging
+#Set-Content .\disk_header $b -Encoding Byte
+

--- a/diskpart.ps1
+++ b/diskpart.ps1
@@ -1,74 +1,4 @@
-# This routine:
-#   Gets the Qubes private volume
-#   Verifies that disk header is nearly all zeros (e.g. never initialized or re-cleared via diskpart's clean command)
-#   Verifies that Q drive does not yet exist
-#   Formats as "Qubes Private Image" 
-#   Assigns letter Q:
-#
-# Note: Private should always be found on PHYSICALDRIVE1 (in Windows under Qubes, that's: 0=BOOT/1=PRIVATE/2=VOLATILE).
-# Note: \\.\PHYSICALDRIVE1 and diskpart's "select disk 1" are assumed to be equivalent.
-# Note: This removes the QM00002 serial number check (which fails in Qubes R4.0).
-
-# We can utilize PInvoke to call win32 API to get raw disk handle
-Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-public class PInvoke {
-    [DllImport("kernel32.dll")] public static extern IntPtr CreateFile(string lpFileName, int dwDesiredAccess, int dwShareMode, IntPtr lpSecurityAttributes, int dwCreationDisposition, int dwFlagsAndAttributes, IntPtr hTemplateFile);
-}
-"@
-
-# Set $bytecount to disk header size
-$blocksize=512
-$blockcount=64
-$bytecount=$blocksize*$blockcount # number of bytes to check at start of disk to "prove" disk is empty.
-
-# Threshold of unexpected bytes
-$maxunexpected=5
-
-# Get raw device with appropriate flags
-$handle = [PInvoke]::CreateFile('\\.\PhysicalDrive1', 0x80000000, 6, 0, 3, 0, 0)
-
-# Convert handle to Powershell object
-$fs = New-Object System.IO.FileStream ($handle, 'Read', $true)
-
-# Set up array to hold disk header data
-$b = [array]::CreateInstance([byte], $bytecount)
-
-# Instead of real error handling around the Read below we'll...
-# ...pre-populate with data that should fail the empty test if not overwritten by a good read
-For($i=0;$i -le ($maxunexpected+1);$i++)
-{
-        $b[$i] = 255
-}
-
-# Read raw volume data into array and clean up object
-$fs.Read($b, 0, $bytecount) | Out-Null
-$fs.Dispose()
-
-# Create flag for whether device is empty
-$headerempty = 1
-
-# Create counter for stray non-zero bytes
-$nonzerocounter = 0
-
-# Check buffer to ensure for all bytes are zeros
-# For some reason, on a new Qubes install, I found two 0x4B aka 75 bytes in the upper half of the first 512-byte block
-foreach($byte in $b)
-{
-	if (($byte -ne 0) -and ($byte -ne 75))
-	{
-		$nonzerocounter++
-	}
-}
-
-if ($nonzerocounter -gt $maxunexpected)
-{
-	$headerempty = 0
-}
-
-# Only invoke diskpart if the header is empty and the Q drive is missing.
-if (($headerempty -ne 0) -and (-not (Get-PSDrive Q)))
+if (-not (Get-PSDrive Q) -and (Get-WmiObject Win32_DiskDrive -filter 'DeviceID = "\\\\.\\PHYSICALDRIVE1" AND Partitions = 0'))
 {
 @"
   select disk 1
@@ -79,7 +9,3 @@ if (($headerempty -ne 0) -and (-not (Get-PSDrive Q)))
   assign letter="Q"
 "@|diskpart
 }
-
-# Write data to file for debugging
-#Set-Content .\disk_header $b -Encoding Byte
-

--- a/diskpart.ps1
+++ b/diskpart.ps1
@@ -36,8 +36,11 @@ $fs = New-Object System.IO.FileStream ($handle, 'Read', $true)
 $b = [array]::CreateInstance([byte], $bytecount)
 
 # Instead of real error handling around the Read below we'll...
-# ...pre-populate with data that should fail the empty if not overwritten by a good read
-$b[0] = 255 
+# ...pre-populate with data that should fail the empty test if not overwritten by a good read
+For($i=0;$i -le ($maxunexpected+1);$i++)
+{
+        $b[$i] = 255
+}
 
 # Read raw volume data into array and clean up object
 $fs.Read($b, 0, $bytecount) | Out-Null

--- a/qubes-tools-combined.wxs
+++ b/qubes-tools-combined.wxs
@@ -504,6 +504,7 @@ ConfigurableDirectory="INSTALLDIR"
     Id="MoveProfiles"
     AllowAdvertise="no"
     Absent="allow"
+    Level="1001"
     Title="Move user profiles"
     Description="Moves user profiles directory (c:\Users) to the HVM&amp;s private disk (private.img)."
     >


### PR DESCRIPTION
Removed from diskpart.ps1:
- QM00002 volume serial number check (which does not work under R4.0).

Added to diskpart.ps1:
- Verify target volume does not appear to contain partitions or other data before overwriting.

Added to README.md:
-  Added cd ~ to beginning of instructions.
-   Added -y to initial dnf invocation to reduce manual intervention.
-   Added note that --nosignature may be needed in order to extract the built ISO from the dnf.